### PR TITLE
Update embedded-hal-async to Latest Version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ repository = "https://github.com/kalkyl/ws2812-async"
 
 [dependencies]
 smart-leds = "0.3.0"
-embedded-hal-async = { version = "=0.2.0-alpha.0" }
+embedded-hal-async = { version = "=1.0.0-rc.1" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,17 @@
 #![no_std]
 
-use embedded_hal_async::spi::{ErrorType, SpiBusWrite};
+use embedded_hal_async::spi::{ErrorType, SpiBus};
 use smart_leds::RGB8;
 
 const PATTERNS: [u8; 4] = [0b1000_1000, 0b1000_1110, 0b1110_1000, 0b1110_1110];
 
 /// N = 12 * NUM_LEDS
-pub struct Ws2812<SPI: SpiBusWrite<u8>, const N: usize> {
+pub struct Ws2812<SPI: SpiBus<u8>, const N: usize> {
     spi: SPI,
     data: [u8; N],
 }
 
-impl<SPI: SpiBusWrite<u8>, const N: usize> Ws2812<SPI, N> {
+impl<SPI: SpiBus<u8>, const N: usize> Ws2812<SPI, N> {
     pub fn new(spi: SPI) -> Self {
         Self { spi, data: [0; N] }
     }


### PR DESCRIPTION
## Problem

When using with the latest version of embassy the following error occurs `error: failed to select a version for 'embedded-hal'.`

## Solution

Bump the version of `embedded-hal-async`. This version bump included [the removal of read-only and write-only spi traits](https://github.com/rust-embedded/embedded-hal/pull/461), hence the change to `SpiBus`. 