### PR TITLE
Use structs for reordering

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,44 +1,58 @@
 #![no_std]
+use core::marker::PhantomData;
 
 use embedded_hal_async::spi::{ErrorType, SpiBus};
 use smart_leds::RGB8;
 
 const PATTERNS: [u8; 4] = [0b1000_1000, 0b1000_1110, 0b1110_1000, 0b1110_1110];
 
-/// The order of the colors
-pub enum ColorOrder {
-    RGB,
-    GRB,
+/// Trait for color order reordering
+pub trait OrderedColors {
+    fn order(color: RGB8) -> [u8; 3];
+}
+
+/// Marker struct for RGB order
+pub struct Rgb;
+
+/// Marker struct for GRB order
+pub struct Grb;
+
+impl OrderedColors for Rgb {
+    fn order(color: RGB8) -> [u8; 3] {
+        [color.r, color.g, color.b]
+    }
+}
+
+impl OrderedColors for Grb {
+    fn order(color: RGB8) -> [u8; 3] {
+        [color.g, color.r, color.b]
+    }
 }
 
 /// N = 12 * NUM_LEDS
-pub struct Ws2812<SPI: SpiBus<u8>, const N: usize> {
+pub struct Ws2812<SPI: SpiBus<u8>, C: OrderedColors, const N: usize> {
     spi: SPI,
     data: [u8; N],
-    color_order: ColorOrder,
+    _color_order: PhantomData<C>,
 }
 
-impl<SPI: SpiBus<u8>, const N: usize> Ws2812<SPI, N> {
+impl<SPI: SpiBus<u8>, C: OrderedColors, const N: usize> Ws2812<SPI, C, N> {
     /// Create a new WS2812 driver, with the given SPI bus
     /// Colors default to RGB order
     pub fn new(spi: SPI) -> Self {
-        Self { spi, data: [0; N], color_order: ColorOrder::RGB }
-    }
-
-    /// Set the color order, if not RGB
-    pub fn set_color_order(&mut self, color_order: ColorOrder) {
-        self.color_order = color_order;
+        Self {
+            spi,
+            data: [0; N],
+            _color_order: PhantomData,
+        }
     }
 
     pub async fn write(
         &mut self,
         iter: impl Iterator<Item = RGB8>,
     ) -> Result<(), <SPI as ErrorType>::Error> {
-        for (led_bytes, RGB8 { r, g, b }) in self.data.chunks_mut(12).zip(iter) {
-            let colors = match self.color_order {
-                ColorOrder::RGB => [r, g, b],
-                ColorOrder::GRB => [g, r, b],
-            };
+        for (led_bytes, rgb8) in self.data.chunks_mut(12).zip(iter) {
+            let colors = C::order(rgb8);
             for (i, mut color) in colors.into_iter().enumerate() {
                 for ii in 0..4 {
                     led_bytes[i * 4 + ii] = PATTERNS[((color & 0b1100_0000) >> 6) as usize];


### PR DESCRIPTION
This PR uses marker structs to set the color order. This should save one match statement as the Color order is determined at compile time (which can be assumed as the Led ordering should not change during runtime).

Usage now would be:

```rust
use ws2812_async::{Ws2812, Grb};
let mut ws: Ws2812<_, Grb, { 12 * 18 }> = Ws2812::new(spi);
```

The rest of the API stays the same (except that there's no `set_color_order` method anymore).