### PR TITLE
Implement smart leds async trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ repository = "https://github.com/kalkyl/ws2812-async"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-smart-leds = "0.4.0"
-embedded-hal-async = { version = "1.0.0" }
+smart-leds-trait = "0.3.1"
+embedded-hal-async = "1.0.0"


### PR DESCRIPTION
Implements the async trait from https://github.com/smart-leds-rs/smart-leds-trait/blob/51207bf4d762a0ddf03a757414c827aaea2043f5/src/lib.rs#L43.

This should make this library fully compatible to other libs using the same trait while not incurring any API changes.

Closes #3.